### PR TITLE
Remove Debian revision number from version.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-arctica-browser (0.0.0.2-1) UNRELEASED; urgency=medium
+arctica-browser (0.0.0.2) UNRELEASED; urgency=medium
 
   * Turn perl-Arctica-Browser-Overlay into actual Arctica Browser project.
 
  -- Mike Gabriel <mike.gabriel@das-netzwerkteam.de>  Wed, 28 Jun 2017 13:30:34 +0200
 
-libarctica-browser-overlay-perl (0.0.0.1-0) unstable; urgency=medium
+libarctica-browser-overlay-perl (0.0.0.1) unstable; urgency=medium
 
   * No changelog entries here... See upstream ChangeLog file.
 


### PR DESCRIPTION
This causes minor packaging issues and seems unnecessary.

    This package has a Debian revision number but there does not seem to be
    an appropriate original tar file or .orig directory in the parent directory;
    (expected one of arctica-browser_0.0.0.2.orig.tar.gz, arctica-browser_0.0.0.2.orig.tar.bz2,
    arctica-browser_0.0.0.2.orig.tar.lzma,  arctica-browser_0.0.0.2.orig.tar.xz or arctica-browser.orig)
    continue anyway? (y/n)
